### PR TITLE
Make Pagination work with Meteor (0.6.0) and Meteorite packages.

### DIFF
--- a/pagination.js
+++ b/pagination.js
@@ -132,4 +132,4 @@ Pagination.prototype._bootstrap = function(prependRoute, currentPage, totalPages
   return html;
 }
 
-var Pagination = new Pagination();
+Pagination = new Pagination();


### PR DESCRIPTION
Remove the local var instantiation of Pagination, as Meteor 0.6.0 (http://meteor.com/blog/2013/04/04/meteor-060-brand-new-distribution-system-app-packages-npm-integration) added file-level JavaScript variable scoping. This will make Pagination work when added via meteorite.
